### PR TITLE
Let __gc be inside of the metatables

### DIFF
--- a/zmq.c
+++ b/zmq.c
@@ -526,15 +526,15 @@ DLL_EXPORT int luaopen_libluazmq(lua_State *L)
 {
     /* context metatable. */
     luaL_newmetatable(L, MT_ZMQ_CONTEXT);
-    lua_createtable(L, 0, sizeof(ctxmethods) / sizeof(luaL_reg) - 1);
     luaL_register(L, NULL, ctxmethods);
-    lua_setfield(L, -2, "__index");
+    lua_pushvalue(L, -1);
+    lua_setfield(L, -1, "__index");
 
     /* socket metatable. */
     luaL_newmetatable(L, MT_ZMQ_SOCKET);
-    lua_createtable(L, 0, sizeof(sockmethods) / sizeof(luaL_reg) - 1);
     luaL_register(L, NULL, sockmethods);
-    lua_setfield(L, -2, "__index");
+    lua_pushvalue(L, -1);
+    lua_setfield(L, -1, "__index");
 
     luaL_register(L, "zmq", zmqlib);
 


### PR DESCRIPTION
I have noticed that __gc() was not called on zmq sockets and contexts.
The __gc was not inside of their metatables.
The __gc was only inside the __index table.

The following is a test case, to see the non-garbage-collecting of sockets.
If your "ulimit -n" is less than 2000, the test failed with "Too many open files".

```
require 'libluazmq'

local ctx = assert(zmq.init(1))
for i = 1, 2000 do
    local socket = assert(ctx:socket(zmq.PULL))
    socket = nil
    collectgarbage()
end
```
